### PR TITLE
Migrate ZIP upload to easySFTP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,16 +61,15 @@ jobs:
       #     recursive: true
 
       - name: UPload Zip
-        uses: Dylan700/sftp-upload-action@latest
+        uses: eiserv/easySFTP@v3
         with:
-          server: ${{ secrets.SERVER_IP }}
+          host: ${{ secrets.SERVER_IP }}
           username: ubuntu
-          password: ${{secrets.SERVER_PASSWD}}
-          port: 22
-          uploads: |
-            ./ =>  ${{ secrets.REMOTE_PATH }}
-          ignore: |
-            !blinker-library-${{steps.version.outputs.prop}}.zip
+          password: ${{ secrets.SERVER_PASSWD }}
+          port: "22"
+          host-key: ${{ secrets.SERVER_HOST_KEY }}
+          source: blinker-library-${{steps.version.outputs.prop}}.zip
+          target: ${{ secrets.REMOTE_PATH }}/blinker-library-${{steps.version.outputs.prop}}.zip
       
       - name: upload json
         uses: garygrossgarten/github-action-scp@release


### PR DESCRIPTION
## What changed

I maintain easySFTP. This replaces the ZIP upload step with `eiserv/easySFTP@v3`.

The workflow still uploads the same versioned `blinker-library-*.zip` file to the same path as `ubuntu` over port 22. The existing overlay behavior is preserved, so no remote files are deleted. The separate SCP upload for `arduino.json` is unchanged.

## Why this fits this deployment

- The source is now the generated ZIP itself instead of the whole workspace plus a negated ignore pattern. This makes it explicit that no other workspace files belong in this upload.
- `SERVER_HOST_KEY` pins the deployment server identity. The current action does not verify the SSH host key.
- easySFTP writes each file through a temporary sibling and renames it into place, and it retries transient failures and reconnects. This reduces the chance of exposing a partial downloadable archive after an interrupted deployment.

The current `Dylan700/sftp-upload-action@latest` reference resolves to v1.2.3 from March 2024. easySFTP provides a maintained rolling `v3` tag instead of relying on `main` or `latest`.

The input mapping and behavior differences are documented in the [Dylan700 migration guide](https://github.com/eiserv/easySFTP/blob/v3/docs/migration.md).

## Maintainer setup

The existing `SERVER_IP`, `SERVER_PASSWD`, and `REMOTE_PATH` secrets remain unchanged.

Before merging, add one repository Actions secret named `SERVER_HOST_KEY`. Its value must contain one or more trusted `SHA256:...` host key fingerprints, one per line. For the existing port 22 setup, obtain the fingerprints from a trusted machine or network:

```console
ssh-keyscan -p 22 <server> | ssh-keygen -lf -
```

Please verify the fingerprints through a trusted channel before saving them. The workflow runs on pushes to `master`, so the secret must exist before this PR is merged.

## Validation

- Parsed `.github/workflows/deploy.yml` as YAML.
- Ran actionlint 1.7.12. The migration itself passes; actionlint still reports the pre-existing `actions/checkout@v2` version warning.
- Ran `git diff --check`.
- Did not run a live SFTP deployment because the repository secrets and server are not available to forked PRs.

If you would rather keep the current action, I would appreciate brief feedback on what is missing or what would need to change for easySFTP to be a fit here.
