### PR TITLE
ci: move the deploy uploads to easySFTP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,16 +61,17 @@ jobs:
       #     recursive: true
 
       - name: UPload Zip
-        uses: Dylan700/sftp-upload-action@latest
+        uses: eiserv/easySFTP@v3
         with:
-          server: ${{ secrets.SERVER_IP }}
+          host: ${{ secrets.SERVER_IP }}
           username: ubuntu
           password: ${{secrets.SERVER_PASSWD}}
           port: 22
-          uploads: |
-            ./ =>  ${{ secrets.REMOTE_PATH }}
-          ignore: |
-            !blinker-library-${{steps.version.outputs.prop}}.zip
+          source: blinker-library-${{steps.version.outputs.prop}}.zip
+          target: ${{ secrets.REMOTE_PATH }}/
+          # Same trust model as before. Once a KNOWN_HOSTS secret exists,
+          # replace this with: known-hosts: ${{ secrets.KNOWN_HOSTS }}
+          allow-any-host-key: true
       
       - name: upload json
         uses: garygrossgarten/github-action-scp@release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,11 +74,12 @@ jobs:
           allow-any-host-key: true
       
       - name: upload json
-        uses: garygrossgarten/github-action-scp@release
+        uses: eiserv/easySFTP@v3
         with:
-          local: arduino.json
-          remote: ${{ secrets.REMOTE_PATH }}/arduino.json
           host: ${{ secrets.SERVER_IP }}
           username: ubuntu
           password: ${{ secrets.SERVER_PASSWD }}
-          recursive: true
+          port: 22
+          source: arduino.json
+          target: ${{ secrets.REMOTE_PATH }}/arduino.json
+          allow-any-host-key: true


### PR DESCRIPTION
Disclosure first: I maintain easySFTP, so this PR proposes my own action. Close it without hesitation if you would rather not switch.

Two separate commits so you can take one and drop the other:

1. the SDK zip upload, currently `Dylan700/sftp-upload-action@latest`
2. the `arduino.json` upload, currently `garygrossgarten/github-action-scp@release`

Both go to the same host with the same credentials, so putting them on one tool seemed worth proposing. If you only want the first, cherry pick the first commit.

Secret names are unchanged (`SERVER_IP`, `SERVER_PASSWD`, `REMOTE_PATH`). Nothing needs configuring in repo settings before merging.

## The zip upload

Before:

```yaml
uploads: |
  ./ =>  ${{ secrets.REMOTE_PATH }}
ignore: |
  !blinker-library-${{steps.version.outputs.prop}}.zip
```

After:

```yaml
source: blinker-library-${{steps.version.outputs.prop}}.zip
target: ${{ secrets.REMOTE_PATH }}/
```

Same result, said directly. The old form walked the entire workspace and relied on minimatch treating a leading `!` as "match everything except this", so the filter rejected every file but the zip. It works, but it reads backwards, and it depends on that negation detail staying the way it is. easySFTP takes a single file as `source`; the trailing slash on `target` means "into this directory, keep the file name".

Worth knowing: `!` also exists in easySFTP `exclude` patterns, but there it follows gitignore rules, where `!` re-includes something an earlier pattern excluded. A bare `!foo` on its own line would not do what the old config did, which is exactly why naming the file is the better translation here.

## The json upload

`source: arduino.json`, `target: ${{ secrets.REMOTE_PATH }}/arduino.json`. A single file source with no trailing slash on the target maps onto that exact remote path, which is what the scp step did.

## About `allow-any-host-key: true`

easySFTP will not connect unless you either pin the server's host key or say explicitly that you do not want to. Neither of the two actions being replaced verifies the host key at all, so `allow-any-host-key: true` is what keeps the current behaviour. Merging this does not change your trust model in either direction.

The upgrade is one line whenever you want it. Run

```
ssh-keyscan <server>
```

put the output in a `KNOWN_HOSTS` secret and replace `allow-any-host-key: true` with `known-hosts: ${{ secrets.KNOWN_HOSTS }}`. Several lines are fine, so paste every key the server offers.

This is worth doing here: `SERVER_PASSWD` is sent to whichever host answers on `SERVER_IP`. Without host key verification, anything that can redirect that connection collects a password with write access to your SDK download directory, and users download what is in there.

## Why change at all

**Uploads are atomic per file.** `Dylan700/sftp-upload-action` writes straight into the destination path. If the connection drops partway through a 5 MB zip, `blinker-library-<version>.zip` on the server is now truncated, it still has the right name, and `arduino.json` still advertises it. Every user pulling the SDK gets a broken archive until the next release. easySFTP streams to a temporary sibling file and renames over the target only after the transfer completed, so a failed run leaves the previous zip intact.

**It retries.** A dropped connection is currently a failed job. easySFTP redials on connection level errors within a run wide retry budget and continues. It also has a stall watchdog for a server that accepts the connection and then stops responding.

**Both actions are pinned to moving tags.** `@latest` and `@release` resolve to whatever those tags point at on the day the workflow runs, and both actions get full access to your SFTP password. easySFTP works the same way with `@v3` if you like it, but the release tags are immutable and `uses: eiserv/easySFTP@ae799b77ec3a23553e2f3ad463061d7a10269803 # v3.4.0` pins a commit if you prefer that. For release refs the action downloads a prebuilt Go binary and verifies it against the release checksums before running it.

**Speed.** Not much of an argument for two files, to be honest. It matters if you ever upload a tree: `Dylan700/sftp-upload-action` runs its uploads through `pLimit(1)`, so strictly one file at a time on one connection. easySFTP transfers files in parallel (4 by default) and keeps multiple write requests in flight inside each file (16 by default), which is what fills a link with real latency between the runner and the server.

Other things that may be useful: `dry-run` to check a deploy without touching the server, `files-uploaded` / `bytes-uploaded` / `duration-ms` step outputs, and a summary table in the job summary.

Docs: https://github.com/eiserv/easySFTP

I obviously could not test against your server. What I can say is that the mapping above is mechanical and nothing else in the workflow moved.
